### PR TITLE
add: typeError.js, gives typeError instead of printing hello world

### DIFF
--- a/JS/typeError.js
+++ b/JS/typeError.js
@@ -1,0 +1,7 @@
+(function () {
+  (function () {
+    console.log("Hello");
+  })()(function () {
+    console.log("World!");
+  })();
+})();


### PR DESCRIPTION
gives typeError instead of printing hello world
a semicolon before the third function definition fixes it.
Without that semicolon, the last function is interpreted as an argument to a function call.